### PR TITLE
Consume latest microsoft/aspnetcore-build-nightly image

### DIFF
--- a/docker-compose.ci.build.yml
+++ b/docker-compose.ci.build.yml
@@ -3,11 +3,11 @@ version: '2'
 services:
   ci-build:
     # using the nightly image from dockerhub
-    # image: microsoft/aspnetcore-build-nightly:1.1.0-preview1-sdk-003933
+    image: microsoft/aspnetcore-build-nightly:1.1.0-preview1-sdk-004050
     # if that's failing, use a custom build where you can specify the various components
     # using custom builds
-    #image: microsoft/aspnetcore-build:1.1.0-msbuild
-    build: docker/
+    # image: microsoft/aspnetcore-build:1.1.0-msbuild
+    # build: docker/
     volumes:
       - .:/src
     working_dir: /src


### PR DESCRIPTION
@SteveLasker you should be able to stop using the custom image now that we have microsoft/aspnetcore-build-nightly:1.1.0-preview1-sdk-004050 on docker hub.